### PR TITLE
Add fixed API to Querry logs on IDR

### DIFF
--- a/insightidr_log_api.yaml
+++ b/insightidr_log_api.yaml
@@ -1,0 +1,1066 @@
+swagger: "3.0"
+info:
+  title: InsightIDR LOG API
+  description: InsightIDR API LOG, manipulate logs and Query
+  version: "1.0"
+  x-logo: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAK4AAACuCAYAAACvDDbuAAAXJ0lEQVR4Xu2dd5xURbbHf7dz93SYGQYEEURBJPnBgLD6wQiYBZFdRUVAlCyLSBxUVARUwAFE95ERnnzA1bcsPlaMKKvPfagoLoiAYIIniBM6pxvqfaqHWcEldLi3u+7tuv/sjlSdW+ecb9etcOqUQAgh4A+3gM4sIHBwdeYx3tyUBTi4HARdWoCDq0u38UZzcDkDurQAB1eXbuON5uByBnRpAQ6uLt3GG83B5Qzo0gIcXF26jTeag8sZ0KUFOLi6dBtvNAeXM6BLC3Bwdek23mgOLmdAlxbg4OrSbbzRHFzOgC4twMHVpdt4ozm4nAFdWoCDq0u38UZzcDkDurQAB1eXbuON5uByBnRpAQ6uLt3GG83B5Qzo0gIcXF26jTeag8sZ0KUFOLi6dBtvNAeXM6BLC3Bwdek23mgOLmdAlxbg4OrSbbzRHFzOgC4twMHVpdt4ozm4nAFdWoCDq0u38UZzcDkDurRAwcBN7tsB5eeDEKwWXRou340WPGUQHE6YXB4IJT6Y3L58N4Gp9xUMXBIJwD93BJLbNgKCDCgCIACgdwCZAchH7dTwt3KSv+l/bqjX8P/p/5qOymj4N/p3ujJOJJO2o0FGg2zazgaZv61zMhkN7j9WFpXR8Pexuhwro+FuJGomdxnMTc6Dqbw5rG3awdS4FSzN28DcuAVMvjIINicgUEHGfQoGLjWpfOQgQiufRHL7e0c9Z1xDq66ZIgNEApQ4YHJAcHhhbt4clpadYWnTBbaOXWFp2hIw0V+X8Z6CggtCIB3ch8DTAyHXHDaskfODDQEozIIJEBQIdjts3frBec0fYG3TEYLFlp9m5OkthQX3qJLiN9tRN+1WQLFweNVyPL13UU6CSFHYLr0V7r7DYW7RAaYSTz3cOn+YAJfaMLFtM4ILRoAkRUAw5uetMKwQQIyAKHHYu/WDo3tf2Lv0gGB3FqY5Kr2VGXCJmETktfmIvr6Ij3dVcu6/iVEkCE4bbJ2vh/veSpgrztTqTZrLZQbc1GSt+hACcwdD+m4PYOLLZFp5n4gxCGYB3rFL4OjaC7BYtXqVZnKZApdqmfzqE/if6g3AZYixmGaey1UwoasSMpw974XrtlEwN26eq8S81mcOXCgKIhtXILxiEgRneV6NUXQvS03g4rC2vRglA6fD1vZC3az/sgduaswgofbRfpD2fQ5Y7EXHU94VVmSYPHZ4Ri2G/eIrj+7o5L0VGb2QTXBTqwzvITh/FIgo6aYXyMjyrBVWRJh8FfCOWQhbp8uYtzmz4CrhAELLH0XiH3RLmC+P5YVzOQmTrxHcD8yG49JrmV5TZxZcuquW2PEPBGcPAJH1v2CeF/DUeAldMnN74BlWBUfXnsz2vOyCS+NtJBGBqrFIfroBsOh7wVwNpvImg8gwNz0b3of+A9ZW7fP22kxexDS4VBHph92omXANBItLF5OGTIzPclkiRmHr0A2+8cth8rG3usM8uDRwxD9/LBIf/RmC3cuyr43XtmQY9iv6wztiFgQH7TjYedgHF4C4dxtqJ/aA4Kpgx3JF0hIS/h6e0S/BdcMApjTWBbhKsA6BBWMg7vxI261gcmxUOFN+yr4xqYDy3ILKTaUe+B5aDmvbi5iZrOkCXMgyIn9bgcgrc0B31jR5zDYI7kYQDBZ4TWJ+kFgwt+1zRYK9643wjpoLwVmiifkzFaoPcGkMw9efIVh1P5RwJFMdT19ekWA+uz28Q59lciJyegVOVkJA4PmxkPZuBcy57EASkGQYpZVrYO/SM/vmqFhTN+Aq9IzarAGQ9u9Uf0NCTsDetRe8o56H4HKraN7CipIOfIPayltSW+i5DhdA13fLz0LFc5sguDyFVYxqQwiNtNDHE16/DNHVEwFHI3UbTGS4eg+Fu/8UwGSczY7gkmmIv/UnwFaqjr0SNXDd/RTcfUcA5sKGneoK3NSa7oMdIbjPUccRDVLMZnjunwXnNf3UlVtAaXLNIdSMvRqQ6IkStX6MBKbyCpROWQNLizYF1E5nPS6JhVE97noQ/yEVnQGY3A74pr4K6zls7hJlQ0hkw1KEV05WPzRUAEr6T0HJrUNU9UGmOuqqx6XKBVfOROz1eRAcKn3+CIG5cTnKntoEU6kx1olJMo66x26A9MMB9ZevFBGW1p3ge3gZzBXNMuVNtfK6Aze56xPUVdLNiDPUMYKchK3zNSidsrzg4zZ1FAKSuz9HcN5QKMGAWiKPkUNSPwbf2IWwd7tRA/npidQduHS4cOSecyHY6cw2t4V1aiIS96NkwAy4+41Iz2Ksl5IlRF6rQuQvLwAmjXIpSDHYL/89fOMWFMwa+gNXTKLuiXsg7ftUlV00EjuE8jkfw3pe54I5Qc0XK8Fa+OcOhfT1VsDiUFP0cb0uif6EJmuPFGxpTHfg0jXJ4KJJiH+wDkhFjOXw0C1emwcVCzenAqiN8CR3bYV/5j2AXP9J1+oh8V/geWABXDcP1uoVp5SrP3CJgsj6hYisnZN7jyIlYel4Ncoff6mgM2Q1PR9cNBWxd5ZDsGm8SSAnYW7dBeVPrClIchEdgksQe/dlhJY+AphzG8PRXqNkwCy4+41Wk52CyVLqjqD24Z5QYuG8/BBJ/Gc0WrANlpZt866z/sClBym/2IJA1UhASuQ2QZPiKH381frDgQZ4Iq+vRPilyfmLW5bCcA9bAFevO3LzQxa21yW4yV2fIjBvFEi4NnuDEQWCpwLlM16D+YyWWZiOrSokHk3FJciHvs9Lb5vSnsiwX94H3uFP5324oEtwxW93IVA1DEo13UHLcgIiJ2Fp9zuUTVlhiMCa5M7/ReDZu0EktbZ30/hhEgJr6/bwjV8BU3mTNCqoV0SX4EqHvkewajikA/uyB1eMwHn9ILgHT4dgzW2srJ47spQkSwi/PBPRTavy19umelwCU2k5fOOX5X05UZfgKrWHEZg3DOI3NMQx2x6GwDP4cTivuzd7+LPkTO1qcvVPCFSNgLR/R95zIQg2B7yjq1JhoWpsCKVrG32CG6hBoGoQxD1fZR2bSy8A8Y5ZAHvn7unaitlyic/eRWD+g4As5hWeeoMQeAY9Duf1A3LoRDI3rT7BDfkRmDcU4q5tWRqLBtY0gm/SWljOap251ZiqQRBcMhXxt5cD1gKcgpYTcPUZCXf/yYA5fxmH9AluOIDg/BFI7vwku888UWBt0x6lU9cVbMtSLfYV/xHUjL8OJJLjubJsGyTFYe9+O7yjn4OQxzy7RQsuXQKzX9YnNcHQ8lEScTgvvwlWmsJTgyeycRXCKyZAsBfo3jM5AWvnniidtAiCNZdzbZkZpzjBpTZSJBAxnpm1silNkmj0wqewNFd/SEKvH6j541VQ6g5nPdbPRqXj6hAZpopWaDT3b3lNGqJPcIO1CDw3MKfJWc4OS0MAPRnr6DkEvpGz0iideZHEZ5sRmNkHcKgUm5x5E+q/WFIQjVfvh+DK3xhbv+BWDYG4+59ZTs6y8VCmdegQREbZ9A3arHHShIDPj0Ji6zuqhHdmqt2v5QlI+AiarDuYuqo1X48+wa39GYH5wyHuZRhcKQ5Lx+4oq1ypyXao9H/fIvDMXZB/qc5ugqoaYQQkcgRN1nJwT2tS6dAPCFY9AOnAfnZ7XDkB98BH4Lp5mPptJATxjzYgtLQSRKRrt4V8OLhpW1/87msE5o2AcuRggXubkzSZHsBs0iy1FWo5u13aeqVbkCQTCC2ZjPiWVxnIG8yHCun6Dcnd21L3QyiB6gLsFKXRTEWE/Yp+8I54VpO1TfnIAdRNuwOK/2f1e/M01Du+CAc3bZMlt29BgF5skqDLWVlGh6X9tiwKylF4x6+Coxvdv1f/SeVMWPVI/uJuT6kCBzdtD8c/3ojgC+M03zxIu0HHFqQJ9Jqeg7KZ62Fyq5T74Rj5JB5B7dTbIR/cDZhZuBGSg5seJ4Qg9uZLCK2clmMGwvRel2mp1CHC4S9qlgg5/sm7CDxzNyO9LbUOBzc9RhQZ4TUzEd3wImDV+EBgei36tVQqo2ELVFRtguDUJuujf8ZAJHf8vcBrt8cahgBKBI1X7uUbEKfiJXUTz4KxSG79b/Z63GQArn4T4L57cqbIp1Ve/P5rBGb0hRKhaUMZeejQqNl5KH9mA9/yPSW4yThqJ/aCfPgAQ71O/WkAwe1F6cRlsJ5/ifpUEYLoxiUIr50NEIYmpA1BNhMXQbDxIJuTOp5OTo7c1QyCozFbKwo0B9nFV8P74EKY3OpvfSohP4IvjELyiw/Z+tJIcTiuvgOe4dos/Z0MBN1t+Sa2bYb/yT4QSgoYWHIiaxIJJXdVoqTPcPV729TNQ1/AP2coSKiOrU0XRULJHQ+jpO/ovB4b0he4REF43QJEXpkBwVmmCSBZCaWHBr1e+KauhbWV+jtltE3hV+Yh+upswMrG5SH/spMAeO6fAee1d+b1B6UrcFO5A6b0hnxoH1PjWyLG4Oh+B7yjn9XkxDAdHtVMvh3K4T1M6U2XwgSnF16acjTPZ/d0Ba585CCqh7ZXLzduVt3rv1ci8TqUz/0A1tYXqCTxeDHJLz5A3fS+ENS++yLX1tIvTUVT+MYvhfWcDrlKy6i+rsCNf/wm/DP7wuRtnpGSmhaWYrC0vwpl01ZpEpdAl//8s+5DcscHEDRLG5qlhejZvQ5d4Bu3BCaP+ruEp2qVbsCtj4h6BPEtrwCW/C27nNalUhTeCSvh6Hb9aYtmUyC5dzv8038PSNqmDc2mbTQFk6PXEHgHV+Y9m7tuwJVp8PiM2yAd+iUrG2tSid6HcM6FKJ36EkxebSaLoeXTEHt7NWNj26PWFIPwjl8Nx2U3aGJeQ/S49HxV8MWHQCdozDw0p8Bto+C+c6ImPY7ir4Z/ziBI+3cV7jDkqYwtB9Hohc9hbnJW3l2ijx6X5sZ67XlE1y9kyoEmtxvesYtg6/Q7TRyX2L4FwYVjQKL0GliGdsuotlIc1ktuRun4hZqspJzOoLoAV6Epl54bDnEPvfeBhVA+erxdhrX9JfBNWK7JThmVH3r5aUQ3vADBpk3AzungONW/k/Ah+KZvguOiK3MRk3VdXYAr/bgbtRN6Hc1AzkbPQ5IReIbOheuGe7I2/inBiIVQ++gdkA98rckwJKdG09zCTg8ar/wyJzG5VGYfXEIQfvkZRNbPYycGlciA1YVGCzbDXK7N1nNi+4cIzOzPwJmyE+AlhuG8bSw8AypzYS+nusyDS6JBVI+5AiQSYuB81VFbJ0Nw3jYengETNdnmTN0MOXMIpK82A1bGhgk0Cs7lQumkFbC2uzQn+HKpzDy4kU1rEF48GoKTketK6WfS6kB51bswNz4zF9uftK64bwdqJ11buHxgp9JKkWG/tCc8I+fClMcEIL9tEtPg0kmZf+YgSD9mnwdXbbKIGIHjqrvgG1Oltuh6eYQgtGoWohv/BMHq1OYdOUgVLGa4h86G88o+OUjJvSrD4BLEtryO0OKHAJK/vKunNilJTZS8Y+bDodE9tnLtEfif6gf58E/sLYEpEiytO6N00jKYSmk8dOEeZsFVwgGEFk9E4tN32RnbUse1ap9aAtNqmBD7+18RXjIRhN4MydhDQj+hdPobsF90lSZj+0zUZRbc5D8/QmDuMBAxx7vMMrHG6coqSTh73QPPkJmAKdu7J07+EpKIIbSiEvH3XwPMWt3DezolT/zvNCWrrWsflE16MTsBKtdiE1yiILBgDBL/sz73+3pVNJhgAXyV62Dr0EVFqb+Kkn/+Ef5n7q+PNxZYGR7V32cmOF0om74elhb5v0XyRMZmEtzkrs/gf6I3YHIW/JPUYDQiJWDrfDVKJy7RJPsifU/8w78i8PxoCBbWJmUKSm4fC1ffUZqEbmbTCzAHLomFUT3hZpDqH/N6hul0xiOxapQ9vgE2Or7T6Kl9ciDEne9DYClsk8bctr4A3vGLYS5vqpHmmYtlC1xFRvTttQgtGg7B2SxzbbSqISdgPvtClD+1DoJDmzNf4v4dqJty49FYYza2tUEUQIjCN+nPsBcoJuFkLmUKXOnHvQjMH1l/Hy1D0VAkGYJn6By4bhio1U8DweXTEX/jRcDGSnYemiI/Ac/I+XBeczs7KztHPcAMuPQijsja2Yi+sZy5iYmp/EyUPboa5jPVv4CE+kGuOYy6yhuhhILs/GDFIFx9/wj3XZVMDdkaeg5mwJW++wp10/qCiBJbv26a8OLKvvAMfVajFEMEsXdfQWj5JACM3ClMRNg6dYNn1ELNgohy/XQxAa4SqoN/Rn9I334JWNgKKhGsZniGzYGje+9cbX3C+iQeTmWoSXy6hYlYYzossp7fDd6RVbC0aKOJzmoILTi4dIMhtPIpxN9aytD47lfTmps2Q9m0/4KpTJtr7aUf9yDw3DDIPx8o+JeGJIKwdrgCvtFVMDc7Ww2+NJNRYHAJ4lvfQ2jhMBBZ/Z2oXK1GEmE4bxoF7wPTchV10vrRTUsRXj4VsKqfbyyjRktRWM7thNIpa2AqK2wcQjrtLii40oE9CC4YCengd2xNyKjlUktBBOWz39Jut0iRUTdjMMQd7wMFy5lAADEM28XXwz3wCVjOOjcdbgpepmDgpvLcPjcCyc82MbWt+y+PJP2wXzUIvgdnazarFr/dhbpHbwUUuphQgLVbRUpdDeu65T44bx4Jc4U28cVaUF4wcAOLH0f8ncUQWIvwT1mZpHrcslkbYT23oxZ2T8kMLpuO2JvUBgXY4qXQWmnCurlwXNEbgoWRFY00rZ13cOl6bWzzKwgveRCwMTqWkpOwXtgDpZOWaLY3L9ccQu24HqAZevLa29LzcoIAS6tOcA9+Ara2F+X3/WmCebpi+QWX3oj4yVsIL50AJRJjZ7H9t1YiItz3PgbXTUM0m+lH31iN8LLxgD2PkzIxAnOzVnBcey+cPfrD5C0/HR/M/ntewaUXy9VO7gUSo70MQ2F7x7qHKDA3bgbvw0tgPUebYYISCSAw+16Ie3Zq9sM4jjgpBpKsg/PWiXD1uhOWs9qyd+Q9w59IfsAlBNKBvaiddFN98woxEUnXMPRWyK494Bu3VLNJWfKrTxB8fgyUYE26rcq8HF0VIRJgEmHrfAs89z0G8xktM5fDaA3twSUKxG+2I7jkEUg/7GQrZO+ETpHhfWgxHN2u08ZlqXRS8xH9y0KVd8rotU1yapUAthJYmreCtf0VcHS/FZZW7SBYGcpwqYJlNQdX+uHrVO9Cr6mHwN4mw3E2VCSYKlqi0Vx6T5k24YskEoR/zjCIuz4+mpknNy/SIzVIBiDYbLCc1x3Wdl1gbXsxrK06wdS4me5WC9K1hqbg0qinmuEXgBATBFZyfp3CMkq0Gt5x/wlXzz+ka7+My4l7PkPt5GsgWLyZD5kUMTVWJaIMwVUGc7MLYD2/C6ztLkqlsjeVN4VgNms2xMlYWQ0raAYuzcYSfWtt/TiO1YnYCQzr7j0EggbXPTW8KvnlR4h/8TEEW+bJ++jn3tLyPJibtoDJ6U6tCggOl4Z4sCtaM3DZVZm3zAgW4OAawYtFqAMHtwidbgSVObhG8GIR6sDBLUKnG0FlDq4RvFiEOnBwi9DpRlCZg2sELxahDhzcInS6EVTm4BrBi0WoAwe3CJ1uBJU5uEbwYhHqwMEtQqcbQWUOrhG8WIQ6cHCL0OlGUJmDawQvFqEOHNwidLoRVObgGsGLRagDB7cInW4ElTm4RvBiEerAwS1CpxtBZQ6uEbxYhDpwcIvQ6UZQmYNrBC8WoQ4c3CJ0uhFU5uAawYtFqAMHtwidbgSVObhG8GIR6sDBLUKnG0FlDq4RvFiEOnBwi9DpRlCZg2sELxahDhzcInS6EVTm4BrBi0WoAwe3CJ1uBJU5uEbwYhHqwMEtQqcbQWUOrhG8WIQ6cHCL0OlGUJmDawQvFqEOHNwidLoRVObgGsGLRagDB7cInW4Elf8fWDe3ft39HcYAAAAASUVORK5CYII=
+  contact:
+    name: "@frikkylikeme"
+    url: https://twitter.com/frikkylikeme
+    email: frikky@shuffler.io
+  x-categories:
+    - SIEM
+servers:
+  - url: https://eu.api.insight.rapid7.com/log_search
+host: eu.api.insight.rapid7.com
+basePath: /log_search
+schemes:
+  - "https:"
+paths:
+  "/download/logs/{logIds}":
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Download Logs
+      operationId: Download_Logs
+      description: >-
+        This endpoint allows you to download and stream log events to your
+        machine for the given log IDs and query parameters over HTTPS.
+
+        <br>
+
+        **Authentication**
+         - Read / Write
+
+         
+        <br>
+
+
+        ## How to stream logs 
+
+        To stream more than one log event, use a colon to seperate each logID. 
+
+
+        <br> 
+
+
+        `https://REGION.rest.logs.insight.rapid7.com/download/logs/aee00b66-a543-43dc-b093-53963c2e8f41:d8eacea6-3dbd-4163-8fc2-3ef5067bd7c9:1c1f2885-ed93-4650-9e14-d46af4bf0886`
+
+
+        <br>
+
+
+        ## Log Limit
+
+        You can download a maximum of 10 logs, or 20 million logs events, as indicated by the query parameter.
+
+
+        <br>
+
+
+        * Maximum number of download requests - 150
+
+        * Maxium download size - 75 GB
+
+        * Time window - 15 minutes
+      parameters:
+        - in: query
+          name: from
+          description: "Lower bound of the time range you want to query against.Format:
+            UNIX timestamp in milliseconds. This is optional if `time_stamp` is
+            supplied."
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: to
+          description: "Upper bound of the time range you want to query against.Format:
+            UNIX timestamp in milliseconds."
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: time_range
+          description: "The relative time range in a readable format.Optional if `from` is
+            supplied. Example: `Last 4 Days`"
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: query
+          description: The LEQL query to match desired log events. Do not use a calculation.
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: limit
+          description: Max number of log events to download; cannot exceed 20 million. The
+            default is 20 million
+          required: false
+          schema:
+            type: string
+        - in: path
+          name: logIds
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content: {}
+  "/log_search/query/{query_id}":
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Get A Long Running Query
+      operationId: Get_A_Long_Running_Query
+      description: >-
+        Depending on the size of the underlying dataset of the complexity of the
+        query, a request may not yield a value straight away. In this case a
+        well-formed query will return an `HTTP 202` response and an ID you can
+        use to check its state.
+
+        <br>
+
+        Use this with:
+
+        * [Get Query](https://insightidr.help.rapid7.com/reference#getquerylogs)
+
+        * [Get Saved Query](https://insightidr.help.rapid7.com/reference#getsavedquery)
+
+
+        <br>
+
+
+        **Authentication**
+         - Read Only
+
+        <br>
+
+
+        Use the `ID` returned to poll the query. In this example the ID is `deace1fd-e605-41cd-a45c-5bf1ff0c3402-1`. 
+
+        The link array object will return the query URL that can be used. 
+
+
+        <br>
+
+
+        ```bash
+
+        curl https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1 -H 'x-api-key: 00112233-4455-6677-8899-aabbccddeeff '
+
+        ```
+
+
+        <br>
+
+
+        There is no limit on how frequently you can poll a query, or how many times you may poll it. However, if you do not poll a query resource for 20 seconds, it will expire. Subsequent calls to that resource will return a 404.
+
+
+        <br>
+
+
+        ## How to poll a query
+
+
+        1. Run the initial GET Query which will return a callback URL. 
+
+
+        <br>
+
+
+        ```json
+
+        {
+          "logs": [
+            "f9c6e2c1-ac7a-4a29-8faa-a8d70f96df70"
+          ],
+          "id": "deace1fd-e605-41cd-a45c-5bf1ff0c3402-1",
+          "progress":0,
+          "query": {
+            "statement": "where(foo) calculate(count:x)",
+            "during": {
+              "to": 100000,
+              "from": 100
+            }
+          },
+          "links": [{
+            "rel": "self",
+            "href": "https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1"
+          }]
+        }
+
+        ```
+
+
+        <br>
+
+
+        **Note**: If the initial GET Query is small, then the results are returned right away and there is no need to use the callback URL to poll.
+         
+        <br>
+
+
+        2. Then use the callback URL to poll request and get log entries. 
+
+
+        <br>
+
+
+        `"href": "https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1"`
+
+
+        <br>
+
+
+        ```json
+
+        {
+          "logs": [
+            "b7b33bce-58f1-42db-a36a-f452aa240d73"
+          ],
+          "events": [
+            {
+              "labels": [],
+              "timestamp": 1583009183456,
+              "sequence_number": 3234730521598636000,
+              "log_id": "b7b33bce-58f1-42db-a36a-f452aa240d73",
+              "message": "{\"http.addr\" : \"176.9.8.97\",\"http.timestamp\" : \"2020-02-29 20:53:34.530862\",\"http.method\" : \"GET\",\"http.path\" : \"/resources/contact-us.php\",\"http.status\" : \"500\",\"http.bytes\" : 4046,\"http.referer\" : \"www.google.ie\",\"http.agent\" : \"Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25\",\"http.host\" : \"eu-prod-3\",\"http.responsetime\" : 11843}",
+              "links": [
+                {
+                  "rel": "Context",
+                  "href": "https://eu.api.insight.rapid7.com/log_search/query/context/3234730521598636032?per_page=50&timestamp=1583009183456&log_keys=b7b33bce-58f1-42db-a36a-f452aa240d73&context_type=SURROUND"
+                }
+              ]
+            }
+          ],
+          "leql": {
+            "statement": "where(http.status)",
+            "during": {
+              "from": 1583009182433,
+              "to": 1585601175000,
+              "time_range": "Last 30 Days"
+            }
+          }
+        }
+
+        ```
+      parameters:
+        - in: path
+          name: query_id
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content: {}
+  /management/logs:
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Get All Logs
+      operationId: Get_All_Logs
+      description: |-
+        Request used to list all Logs for an account.
+
+        <br>
+
+        **Authentication**
+         - Read Write
+         - Read Only
+      parameters: []
+      requestBody:
+        content: {}
+  "/management/logs/{logId}":
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Get a Log
+      operationId: Get_a_Log
+      description: |+
+        Request used to get a specific Log from an account.
+
+        <br>
+
+        **Authentication**
+         - Read Write
+         - Read Only
+
+
+
+
+
+
+
+
+      parameters:
+        - in: path
+          name: logId
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content: {}
+  /management/logsets:
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Get All Log Sets
+      operationId: Get_All_Log_Sets
+      description: |-
+        Get all Log Sets from an account.
+
+        <br>
+
+        **Authentication**
+         - Owner
+         - Read Write
+         - Read Only
+      parameters: []
+      requestBody:
+        content: {}
+  "/management/logsets/{logsetid}":
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Get A Log Set
+      operationId: Get_A_Log_Set
+      description: |-
+        Get a specific LogSet from an account. 
+
+        <br>
+
+        **Authentication**
+         - Owner
+         - Read Write
+         - Read Only
+      parameters:
+        - in: path
+          name: logsetid
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content: {}
+  "/query/logs/{log_id}":
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Get A Query
+      operationId: Get_A_Query
+      description: >-
+        Query your Log entries using a LEQL query.
+
+
+        <br>
+
+
+        **Authentication**
+         - Read Only
+
+         
+        <br>
+
+
+        Depending on the size of the underlying dataset of the complexity of the query, a request may not yield a value straight away. In this case a well-formed query will return an `HTTP 202` response and an ID you can use to check its state.
+
+
+        <br>
+
+
+        Use the `ID` returned to poll the query. In this example the ID is `deace1fd-e605-41cd-a45c-5bf1ff0c3402-1`. 
+
+        The link array object will return the query URL that can be used. 
+
+
+        <br>
+
+
+        ```bash
+
+        curl https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1 -H 'x-api-key: 00112233-4455-6677-8899-aabbccddeeff '
+
+        ```
+
+
+        <br>
+
+
+        There is no limit on how frequently you can poll a query, or how many times you may poll it. However, if you do not poll a query resource for 20 seconds, it will expire. Subsequent calls to that resource will return a 404.
+
+
+        <br>
+
+
+        ## How to poll a query
+
+        1. Run the initial GET Query which will return a callback URL. 
+
+
+        <br>
+
+
+        ```json
+
+        {
+          "logs": [
+            "f9c6e2c1-ac7a-4a29-8faa-a8d70f96df70"
+          ],
+          "id": "deace1fd-e605-41cd-a45c-5bf1ff0c3402-1",
+          "progress":0,
+          "query": {
+            "statement": "where(foo) calculate(count:x)",
+            "during": {
+              "to": 100000,
+              "from": 100
+            }
+          },
+          "links": [{
+            "rel": "self",
+            "href": "https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1"
+          }]
+        }
+
+        ```
+
+
+        <br>
+
+
+        **Note**: If the initial GET Query is small, then the results are returned right away and there is no need to use the callback URL to poll. 
+
+
+        <br>
+
+
+        2. Then use the callback URL to poll request and get log entries. 
+
+
+        <br>
+
+
+        `"href": "https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1"`
+
+
+        <br>
+
+
+        ```json
+
+        {
+          "logs": [
+            "b7b33bce-58f1-42db-a36a-f452aa240d73"
+          ],
+          "events": [
+            {
+              "labels": [],
+              "timestamp": 1583009183456,
+              "sequence_number": 3234730521598636000,
+              "log_id": "b7b33bce-58f1-42db-a36a-f452aa240d73",
+              "message": "{\"http.addr\" : \"176.9.8.97\",\"http.timestamp\" : \"2020-02-29 20:53:34.530862\",\"http.method\" : \"GET\",\"http.path\" : \"/resources/contact-us.php\",\"http.status\" : \"500\",\"http.bytes\" : 4046,\"http.referer\" : \"www.google.ie\",\"http.agent\" : \"Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25\",\"http.host\" : \"eu-prod-3\",\"http.responsetime\" : 11843}",
+              "links": [
+                {
+                  "rel": "Context",
+                  "href": "https://eu.api.insight.rapid7.com/log_search/query/context/3234730521598636032?per_page=50&timestamp=1583009183456&log_keys=b7b33bce-58f1-42db-a36a-f452aa240d73&context_type=SURROUND"
+                }
+              ]
+            }
+          ],
+          "leql": {
+            "statement": "where(http.status)",
+            "during": {
+              "from": 1583009182433,
+              "to": 1585601175000,
+              "time_range": "Last 30 Days"
+            }
+          }
+        }
+
+        ```
+      parameters:
+        - in: query
+          name: query
+          description: >-
+            A valid [LEQL
+            query](https://docs.logentries.com/docs/search#section-leql) to run
+            against the log. 
+
+            Format: url-encoded string.
+
+            Example: `query=where(foo=bar)`
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: from
+          description: |-
+            Lower bound of the time range you want to query against. 
+            Format: UNIX timestamp in milliseconds. 
+            Example:`1450557004000`
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: to
+          description: |-
+            Upper bound of the time range you want to query against. 
+            Format:UNIX timestamp in milliseconds. 
+            Example:`1460557604000`
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: per_page
+          description: |-
+            Number of log entries to return per page. Default of 50.
+            Example: `per_page=50`
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: sequence_number
+          description: |-
+            The earlier sequence number of a log entry to start searching from. 
+            Example: `sequence_number=10`
+          required: false
+          schema:
+            type: string
+        - in: path
+          name: log_id
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content: {}
+  /query/saved_queries:
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Get All Saved Queries
+      operationId: Get_All_Saved_Queries
+      description: >-
+        Returns all saved queries. To return a specific save query use the
+        `query_id` parameter.
+
+
+        <br>
+
+
+        **Authentication**
+
+        * Owner
+
+        * Read Write
+
+        * Read Only
+
+
+        <br>
+
+
+        Depending on the size of the underlying dataset of the complexity of the query, a request may not yield a value straight away. In this case a well-formed query will return an `HTTP 202` response and an ID you can use to check its state.
+
+
+        <br>
+
+
+        Use the `ID` returned to poll the query. In this example the ID is `deace1fd-e605-41cd-a45c-5bf1ff0c3402-1`. 
+
+        The link array object will return the query URL that can be used. 
+
+
+        <br>
+
+
+        ```bash
+
+        curl https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1 -H 'x-api-key: 00112233-4455-6677-8899-aabbccddeeff '
+
+        ```
+
+        <br>
+
+
+        There is no limit on how frequently you can poll a query, or how many times you may poll it. However, if you do not poll a query resource for 20 seconds, it will expire. Subsequent calls to that resource will return a 404.
+
+
+        <br>
+
+
+        ## How to poll a query
+
+
+        <br>
+
+
+        1. Run the initial GET Query which will return a callback URL.
+         
+        <br>
+
+
+        ```json
+
+        {
+          "logs": [
+            "f9c6e2c1-ac7a-4a29-8faa-a8d70f96df70"
+          ],
+          "id": "deace1fd-e605-41cd-a45c-5bf1ff0c3402-1",
+          "progress":0,
+          "query": {
+            "statement": "where(foo) calculate(count:x)",
+            "during": {
+              "to": 100000,
+              "from": 100
+            }
+          },
+          "links": [{
+            "rel": "self",
+            "href": "https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1"
+          }]
+        }
+
+        ```
+
+
+        <br>
+
+
+        **Note**: If the initial GET Query is small, then the results are returned right away and there is no need to use the callback URL to poll.
+         
+        <br>
+
+
+        2. Then use the callback URL to poll request and get log entries. 
+
+
+        <br>
+
+
+        `"href": "https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1"`
+
+
+        <br>
+
+
+        ```json
+
+        {
+          "logs": [
+            "b7b33bce-58f1-42db-a36a-f452aa240d73"
+          ],
+          "events": [
+            {
+              "labels": [],
+              "timestamp": 1583009183456,
+              "sequence_number": 3234730521598636000,
+              "log_id": "b7b33bce-58f1-42db-a36a-f452aa240d73",
+              "message": "{\"http.addr\" : \"176.9.8.97\",\"http.timestamp\" : \"2020-02-29 20:53:34.530862\",\"http.method\" : \"GET\",\"http.path\" : \"/resources/contact-us.php\",\"http.status\" : \"500\",\"http.bytes\" : 4046,\"http.referer\" : \"www.google.ie\",\"http.agent\" : \"Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25\",\"http.host\" : \"eu-prod-3\",\"http.responsetime\" : 11843}",
+              "links": [
+                {
+                  "rel": "Context",
+                  "href": "https://eu.api.insight.rapid7.com/log_search/query/context/3234730521598636032?per_page=50&timestamp=1583009183456&log_keys=b7b33bce-58f1-42db-a36a-f452aa240d73&context_type=SURROUND"
+                }
+              ]
+            }
+          ],
+          "leql": {
+            "statement": "where(http.status)",
+            "during": {
+              "from": 1583009182433,
+              "to": 1585601175000,
+              "time_range": "Last 30 Days"
+            }
+          }
+        }
+
+        ```
+      parameters:
+        - in: query
+          name: queryid
+          description: |-
+            The UUID to return a specific query.
+            Example: `de305d54-75b4-431b-adb2-eb6b9e546014`
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content: {}
+    post:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Create a Saved Query
+      operationId: Create_a_Saved_Query
+      description: |-
+        Request to create a new Saved Query.
+
+        <br>
+
+        **Authentication**
+        * Owner
+        * Read Write
+      parameters:
+        - in: header
+          name: Content-Type
+          multiline: false
+          description: Header generated by shuffler.io OpenAPI
+          required: false
+          example: application/json
+          schema:
+            type: string
+      requestBody:
+        content: {}
+  "/query/saved_queries/{saved_query_id}":
+    delete:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Delete A Saved Query
+      operationId: Delete_A_Saved_Query
+      description: Delete a Saved Query.
+      parameters:
+        - in: path
+          name: saved_query_id
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Content-Type
+          multiline: false
+          description: Header generated by shuffler.io OpenAPI
+          required: false
+          example: application/json
+          schema:
+            type: string
+      requestBody:
+        content: {}
+    patch:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Modify a Saved Query
+      operationId: Modify_a_Saved_Query
+      description: Request used to update a given resource for a specified saved query.
+      parameters:
+        - in: path
+          name: saved_query_id
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Content-Type
+          multiline: false
+          description: Header generated by shuffler.io OpenAPI
+          required: false
+          example: application/json
+          schema:
+            type: string
+      requestBody:
+        content: {}
+    put:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Update a Saved Query
+      operationId: Update_a_Saved_Query
+      description: >-
+        Replace the attributes of a saved query.
+
+
+        <br>
+
+
+        Full object must be used when performing this request otherwise it will fail.
+      parameters:
+        - in: path
+          name: saved_query_id
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Content-Type
+          multiline: false
+          description: Header generated by shuffler.io OpenAPI
+          required: false
+          example: application/json
+          schema:
+            type: string
+      requestBody:
+        content: {}
+  "/query/saved_query/{saved_query_id}":
+    get:
+      responses:
+        default:
+          description: default
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ""
+      summary: Get A Saved Query
+      operationId: Get_A_Saved_Query
+      description: >-
+        Request used to Query your Log entries using a Saved Query.
+
+
+        <br>
+
+
+        Note that if you are already using a from and to value in your Saved Query then they are not required for performing a GET request.
+
+
+        <br>
+
+
+        **Authentication**
+         - Read Only
+
+         
+        <br>
+
+
+        Depending on the size of the underlying dataset of the complexity of the query, a request may not yield a value straight away. In this case a well-formed query will return an `HTTP 202` response and an ID you can use to check its state.
+
+
+        <br>
+
+
+        Use the `ID` returned to poll the query. In this example the ID is `deace1fd-e605-41cd-a45c-5bf1ff0c3402-1`. 
+
+        The link array object will return the query URL that can be used. 
+
+
+        <br>
+
+
+        ```bash
+
+        curl https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1 -H 'x-api-key: 00112233-4455-6677-8899-aabbccddeeff '
+
+        ```
+
+
+        <br>
+
+
+        There is no limit on how frequently you can poll a query, or how many times you may poll it. However, if you do not poll a query resource for 20 seconds, it will expire. Subsequent calls to that resource will return a 404.
+
+
+        <br>
+
+
+        ## How to poll a query
+
+
+        1. Run the initial GET Query which will return a callback URL. 
+
+
+        <br>
+
+
+        ```json
+
+        {
+          "logs": [
+            "f9c6e2c1-ac7a-4a29-8faa-a8d70f96df70"
+          ],
+          "id": "deace1fd-e605-41cd-a45c-5bf1ff0c3402-1",
+          "progress":0,
+          "query": {
+            "statement": "where(foo) calculate(count:x)",
+            "during": {
+              "to": 100000,
+              "from": 100
+            }
+          },
+          "links": [{
+            "rel": "self",
+            "href": "https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1"
+          }]
+        }
+
+        ```
+
+
+        <br>
+
+
+        **Note**: If the initial GET Query is small, then the results are returned right away and there is no need to use the callback URL to poll.
+         
+        <br>
+
+
+        2. Then use the callback URL to poll request and get log entries. 
+
+
+        <br>
+
+
+        `"href": "https://us.rest.logs.insight.rapid7.com/query/deace1fd-e605-41cd-a45c-5bf1ff0c3402-1"`
+
+
+        <br>
+
+
+        ```json
+
+        {
+          "logs": [
+            "b7b33bce-58f1-42db-a36a-f452aa240d73"
+          ],
+          "events": [
+            {
+              "labels": [],
+              "timestamp": 1583009183456,
+              "sequence_number": 3234730521598636000,
+              "log_id": "b7b33bce-58f1-42db-a36a-f452aa240d73",
+              "message": "{\"http.addr\" : \"176.9.8.97\",\"http.timestamp\" : \"2020-02-29 20:53:34.530862\",\"http.method\" : \"GET\",\"http.path\" : \"/resources/contact-us.php\",\"http.status\" : \"500\",\"http.bytes\" : 4046,\"http.referer\" : \"www.google.ie\",\"http.agent\" : \"Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25\",\"http.host\" : \"eu-prod-3\",\"http.responsetime\" : 11843}",
+              "links": [
+                {
+                  "rel": "Context",
+                  "href": "https://eu.api.insight.rapid7.com/log_search/query/context/3234730521598636032?per_page=50&timestamp=1583009183456&log_keys=b7b33bce-58f1-42db-a36a-f452aa240d73&context_type=SURROUND"
+                }
+              ]
+            }
+          ],
+          "leql": {
+            "statement": "where(http.status)",
+            "during": {
+              "from": 1583009182433,
+              "to": 1585601175000,
+              "time_range": "Last 30 Days"
+            }
+          }
+        }
+
+        ```
+      parameters:
+        - in: query
+          name: from
+          description: |-
+            Lower bound of the time range you want to query against.
+            Format: UNIX timestamp in milliseconds
+            Example: `from=1450557604000`
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: to
+          description: |-
+            Lower bound of the time range you want to query against.
+            Format: UNIX timestamp in milliseconds
+            Example: `to=1460557604000`
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: per_page
+          description: |-
+            Number of log entries to return per page. Default of 50.
+            Example: `per_page=50`	
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: sequence_number
+          description: |-
+            The earlier sequence number of a log entry to start searching from.
+            Example:`sequence_number=10`	
+          required: false
+          schema:
+            type: string
+        - in: path
+          name: saved_query_id
+          description: Generated by shuffler.io OpenAPI
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content: {}
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+tags:
+  - name: Query
+  - name: Logs
+  - name: Logsets
+  - name: Saved Queries
+  - name: IDR


### PR DESCRIPTION
It's missing hidden options. Like requesting LQL Query, create Saved Query etc. This could be useful to create Saved Query on the go or Get extra intel from logs and it's partially unfinish